### PR TITLE
compatibility with erlang.mk

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,4 @@
 .DS_Store
-Makefile
 .eunit
 logs
 /ebin/*

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,16 @@
+REBAR=$(shell which rebar || echo ./rebar)
+
+.PHONY: all compile deps clean-all
+
+DIRS=src
+
+all: deps compile
+
+compile:
+	$(REBAR) compile
+
+deps:
+	$(REBAR) get-deps
+
+clean-all:
+	$(REBAR) clean

--- a/src/n2o.app.src
+++ b/src/n2o.app.src
@@ -2,6 +2,7 @@
     {description,  "N2O SXC"},
     {vsn,          "3.0"},
     {applications, [kernel, stdlib, cowboy, ranch, gproc]},
+    {modules, []},
     {registered,   []},
     {mod, { n2o_app, []}},
     {env, []}


### PR DESCRIPTION
Lets erlang.mk use rebar when n2o is included as a dependency.
