### PR TITLE
add mimetypes and erlydtl for relx

### DIFF
--- a/src/n2o.app.src
+++ b/src/n2o.app.src
@@ -1,7 +1,7 @@
 {application, n2o, [
     {description,  "N2O SXC"},
     {vsn,          "3.0"},
-    {applications, [kernel, stdlib, cowboy, ranch, gproc]},
+    {applications, [kernel, stdlib, cowboy, ranch, gproc, mimetypes, erlydtl]},
     {modules, []},
     {registered,   []},
     {mod, { n2o_app, []}},


### PR DESCRIPTION
relx needs applications defined in .src to determine dependencies.
