### PR TITLE
check enviroment vars for config values

### DIFF
--- a/src/wf.erl
+++ b/src/wf.erl
@@ -146,9 +146,7 @@ render(X) -> wf_core:render(X).
 
 config_multiple(Keys) -> [config(Key, "") || Key <- Keys].
 config(Key) -> config(n2o, Key, "").
-config(App,Key) -> config(App,Key, "").
-config(App, Key, Default) -> case application:get_env(App,Key) of
-                              undefined -> Default;
-                              {ok,V} -> V end.
+config(App, Key) -> config(App,Key, "").
+config(App, Key, Default) -> wf_utils:config(App, Key, Default).
 
 version() -> "0.10.0-5HT".

--- a/src/wf_utils.erl
+++ b/src/wf_utils.erl
@@ -49,3 +49,13 @@ is_char(C) -> is_integer(C) andalso C >= 0 andalso C =< 255.
 
 is_string([N | _] = PossibleString) when is_number(N) -> lists:all(fun is_char/1, PossibleString);
 is_string(_)                                          -> false.
+
+config(App, Key, Default) -> case application:get_env(App,Key) of
+                                undefined -> os_env(Key, Default);
+                                {ok,V} -> V end.
+
+os_env(Key) -> os_env(Key, "").
+os_env(Key, Default) when is_atom(Key) ->
+    os_env(string:to_upper(atom_to_list(Key)), Default);
+os_env(Key, Default) ->
+    case os:getenv(Key) of false -> Default; V -> V end.


### PR DESCRIPTION
Keep same behavior for getting config values from config file.

If a key is not found, checks for environment variable:
- if key is a string, checks literal, case sensitive
- if key is an atom, converts to upper case string
