### PR TITLE
Use env in sample release scripts

### DIFF
--- a/samples/release.sh
+++ b/samples/release.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 NODE=${1:-"web"}
 
@@ -20,4 +20,3 @@ else
    echo "Releasing node $NODE..."
    release_node $NODE
 fi
-

--- a/samples/release_sync.sh
+++ b/samples/release_sync.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # Warning for Mac users: bash 4.0 needed
 


### PR DESCRIPTION
This fixes a bug that would not allow the examples to be run on OS X. I tested 10.9 Mavericks, and the onboard bash version 3.2 does not support declare -A, which prevents the scripts from being executed.

With the use of env, a newer bash version can be installed ie via homebrew.
