### PR TITLE
Remove deprecated function crypto:sha/1

### DIFF
--- a/src/elements/element_upload.erl
+++ b/src/elements/element_upload.erl
@@ -104,5 +104,5 @@ control_event(Cid, Tag) ->
 
 hash(Filename) ->
   {ok, Content} = file:read_file(Filename),
-  <<Hash:160/integer>> = crypto:sha(Content),
+  <<Hash:160/integer>> = crypto:hash(sha, Content),
   lists:flatten(io_lib:format("~40.16.0b", [Hash])).


### PR DESCRIPTION
crypto:sha/1 is deprecated and will be removed in in a future release; use crypto:hash/2
