### PR TITLE
rest dependency tag 1.5.0 instead of 1.5

### DIFF
--- a/rebar.config
+++ b/rebar.config
@@ -3,6 +3,6 @@
 {deps,[
     {cowboy,        ".*", {git, "git://github.com/extend/cowboy",          {tag,"0.9.0"}}},
     {gproc,         ".*", {git, "git://github.com/uwiger/gproc.git",       {tag,"0.3"}}},
-    {rest,          ".*", {git, "git://github.com/synrc/rest.git",         {tag,"1.5"}}},
+    {rest,          ".*", {git, "git://github.com/synrc/rest.git",         {tag,"1.5.0"}}},
     {erlydtl,       ".*", {git, "git://github.com/evanmiller/erlydtl.git", {tag,"0.8.0"}}}
 ]}.


### PR DESCRIPTION
Hi, just a small fix: rest was tagged 1.5, should be 1.5.0
