### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -290,7 +290,7 @@ directories with release lib directories and also links to BERT, N2O
 and jQuery javascript. After making release you should run:
 
     $ ./nitrogen_static.sh
-    $ ./release_sync.sh
+    $ ./release_sync.sh - Note to Mac users: you will need to update bash to 4.0 or greater for this script to run successfully.
 
 Now you can edit site sources and sync will automaticaly recompile
 and reload modules in release.


### PR DESCRIPTION
I use mac and linux. I added a note to the developer scripts section to notify mac users to update bash to 4.0 or greater to successfully run the release_sync.sh script.
