### PR TITLE
Removed hardcoded port

### DIFF
--- a/src/wf_core.erl
+++ b/src/wf_core.erl
@@ -7,7 +7,7 @@ transition(Actions) -> receive {init,A} -> transition(A); {'N2O',Pid} -> Pid ! A
 run(Req) ->
     Pid = spawn(fun() -> transition([]) end),
     wf_context:script(["var transition = {pid: '", wf:pickle(Pid), "', ",
-                                         "port:'", wf:to_list(wf:config(n2o,port,8000)),"'}"]),
+                                         "port:'", wf:to_list(wf:config(n2o,port)),"'}"]),
     Ctx = wf_context:init_context(Req),
     Ctx1 = fold(init,Ctx#context.handlers,Ctx),
     wf_context:actions(Ctx1#context.actions),


### PR DESCRIPTION
Is there a reason why the port needs to be hardcoded here when it can be specified in the sys.config file? This make doing things like secure websockets a little more clunky.
