### PR TITLE
modify the ‘text’ to ‘body’ for some sample code in document

### DIFF
--- a/README.md
+++ b/README.md
@@ -134,17 +134,17 @@ and async interprocesses communications:
     body() -> %% area of http handler
         {ok,Pid} = wf:comet(fun() -> chat_loop() end),
       [ #span { text= <<"Your chatroom name: ">> },
-        #textbox { id=userName, text= <<"Anonymous">> },
+        #textbox { id=userName, body= <<"Anonymous">> },
         #panel { id=chatHistory, class=chat_history },
         #textbox { id=message },
-        #button { id=sendButton, text= <<"Send">>,
+        #button { id=sendButton, body= <<"Send">>,
                   postback={chat,Pid}, source=[userName,message] },
         #panel { id=status } ].
 
     event({chat,Pid}) -> %% area of websocket handler
         Username = wf:q(userName),
         Message = wf:q(message),
-        Terms = [ #span { text="Message sent" }, #br{} ],
+        Terms = [ #span { body="Message sent" }, #br{} ],
         wf:insert_bottom(chatHistory, Terms),
         wf:reg(room),
         Pid ! {message, Username, Message};
@@ -154,8 +154,8 @@ and async interprocesses communications:
     chat_loop() -> %% background worker ala comet
         receive
             {message, Username, Message} ->
-                Terms = [ #span { text=Username }, ": ",
-                          #span { text=Message }, #br{} ],
+                Terms = [ #span { body=Username }, ": ",
+                          #span { body=Message }, #br{} ],
                 wf:insert_bottom(chatHistory, Terms),
                 wf:flush(room); %% we flush to websocket process by key
             Unknown -> error_logger:info_msg("Unknown Looper Message ~p",[Unknown])

--- a/doc/elements.tex
+++ b/doc/elements.tex
@@ -24,7 +24,7 @@ Usually ``static'' means elements that don't use postback parameter:
 
 \vspace{1\baselineskip}
 \begin{lstlisting}
-    #textbox { id=userName, text= <<"Anonymous">> },
+    #textbox { id=userName, body= <<"Anonymous">> },
     #panel { id=chatHistory, class=chat_history }
 \end{lstlisting}
 \vspace{1\baselineskip}
@@ -48,7 +48,7 @@ Element definition specifies the list of {\bf source} elements providing data to
 \vspace{1\baselineskip}
 \begin{lstlisting}
     {ok,Pid} = wf:async(fun() -> chat_loop() end),
-    #button { id=sendButton, text= <<"Send">>, 
+    #button { id=sendButton, body= <<"Send">>, 
               postback={chat,Pid}, source=[userName,message] }.
 \end{lstlisting}
 \vspace{1\baselineskip}
@@ -197,7 +197,7 @@ bind\_script should be set to false.
 Sample:
 
 \begin{lstlisting}
-#button { id=sendButton, text= <<"Send">>,
+#button { id=sendButton, body= <<"Send">>,
           postback={chat,Pid}, source=[userName,message] }.
 \end{lstlisting}
 

--- a/doc/index.tex
+++ b/doc/index.tex
@@ -136,7 +136,7 @@ interprocesses communication.
     event({chat,Pid}) ->
         Username = wf:q(userName),
         Message = wf:q(message),
-        Terms = [ #span { text="Message sent" }, #br{} ],
+        Terms = [ #span { body="Message sent" }, #br{} ],
         wf:reg(room),
         Pid ! {message, Username, Message}.
 


### PR DESCRIPTION
For the element only has 'body' property not 'text', so I modified the remain sample code in document.
