### PR TITLE
added configurable logging handler

### DIFF
--- a/src/handlers/n2o_log.erl
+++ b/src/handlers/n2o_log.erl
@@ -1,0 +1,17 @@
+-module(n2o_log).
+-author('Roman Gladkov').
+-export([info/3, warning/3, error/3]).
+
+
+info(Module, String, Args) ->
+    error_logger:info_msg(format_message(Module, String), Args).
+
+warning(Module, String, Args) ->
+    error_logger:warning_msg(format_message(Module, String), Args).
+
+error(Module, String, Args) ->
+    error_logger:error_msg(format_message(Module, String), Args).
+
+
+format_message(Module, String) ->
+    wf:to_list([Module, ":", String, "~n"]).

--- a/src/wf.erl
+++ b/src/wf.erl
@@ -161,26 +161,26 @@ reply(Status,Req) -> ?BRIDGE:reply(Status,Req).
 
 % Logging API
 
-log_modules() -> [].
+-define(LOGGER, (wf:config(n2o,log_backend,n2o_log))).
+log_modules() -> [?LOGGER].
 -define(ALLOWED, (wf:config(n2o,log_modules,wf))).
 
 log(Module, String, Args, Fun) ->
-    case lists:member(Module,?ALLOWED:log_modules()) of
-         true -> %error_logger:Fun(String, Args);
-                   io:format(String ++ "\n\r", Args);
-         false -> skip end.
+    case lists:member(?LOGGER, ?ALLOWED:log_modules()) of
+        true -> ?LOGGER:Fun(Module, String, Args);
+        false -> skip end.
 
-info(Module,String, Args) ->  log(Module,String, Args, info_msg).
-info(String, Args) -> log(?MODULE, String, Args, info_msg).
-info(String) -> log(?MODULE, String, [], info_msg).
+info(Module, String, Args) -> log(Module, String, Args, info).
+info(String, Args) -> log(?MODULE, String, Args, info).
+info(String) -> log(?MODULE, String, [], info).
 
-warning(Module,String, Args) -> log(Module, String, Args, warning_msg).
-warning(String, Args) -> log(?MODULE, String, Args, warning_msg).
-warning(String) -> log(?MODULE,String, [], warning_msg).
+warning(Module, String, Args) -> log(Module, String, Args, warning).
+warning(String, Args) -> log(?MODULE, String, Args, warning).
+warning(String) -> log(?MODULE, String, [], warning).
 
-error(Module,String, Args) -> log(Module, String, Args, error_msg).
-error(String, Args) -> log(?MODULE, String, Args, error_msg).
-error(String) -> log(?MODULE, String, [], error_msg).
+error(Module, String, Args) -> log(Module, String, Args, error).
+error(String, Args) -> log(?MODULE, String, Args, error).
+error(String) -> log(?MODULE, String, [], error).
 
 % Convert and Utils API
 
@@ -230,4 +230,3 @@ setkey(Name,Pos,List,New) ->
     case lists:keyfind(Name,Pos,List) of
         false -> [New|List];
         Element -> lists:keyreplace(Name,Pos,List,New) end.
-


### PR DESCRIPTION
By default n2o will use n2o_log module. A minimal custom logger should have implemented 3 methods info/3, warning/3, error/3.

```
> wf:info("test").
ok

=INFO REPORT==== 2-Oct-2014::19:57:15 ===
wf:test
3> wf:info("test ~p", [1]).

=INFO REPORT==== 2-Oct-2014::19:57:30 ===
wf:test 1
ok

4> wf:info(index, "event(~p)", [init]).

=INFO REPORT==== 2-Oct-2014::19:57:55 ===
index:event(init)
ok

```

Example (implemented 3 basic methods and critical/2 which is available through wf:log(n2o_epic_logger, "boom", [], critical)):

``` erlang
-module(n2o_epic_logger).
-export([info/3, warning/3, error/3]).
-export([critical/3]).

info(_Module, String, Args) ->
    io:format("Epic info message:" ++ String, Args).

warning(_Module, String, Args) ->
    io:format("Epic warning message:" ++ String, Args).

error(_Module, String, Args) ->
   io:format("Epic error message:" ++ String, Args).

critical(_Module, String, Args) ->
   io:format("Epic critical message:" ++ String, Args).
```

Config:

```
{n2o, [
  {log_backend, n2o_epic_logger}
]}
```
