### PR TITLE
allow write logs by default (from wf module)

### DIFF
--- a/src/wf.erl
+++ b/src/wf.erl
@@ -162,7 +162,7 @@ reply(Status,Req) -> ?BRIDGE:reply(Status,Req).
 % Logging API
 
 -define(LOGGER, (wf:config(n2o,log_backend,n2o_io))).
-log_modules() -> [?LOGGER].
+log_modules() -> [wf].
 -define(ALLOWED, (wf:config(n2o,log_modules,wf))).
 
 log(Module, String, Args, Fun) ->


### PR DESCRIPTION
Should be allowed logs writing using `info|warning|error/1,2` by default (without configuration)?
