### PR TITLE
Action Transfer

### DIFF
--- a/include/wf.hrl
+++ b/include/wf.hrl
@@ -198,6 +198,7 @@
 -record(alert,   {?ACTION_BASE(action_alert), text}).
 -record(confirm, {?ACTION_BASE(action_confirm), text, postback, delegate}).
 -record(jq,      {?ACTION_BASE(action_jq), property, method, args=[], right, format="~s"}).
+-record(transfer,{?ACTION_BASE(action_transfer), state, events=[] }).
 
 %Binary messaging to browser
 -record(binary, {

--- a/src/nitrogen/actions/action_transfer.erl
+++ b/src/nitrogen/actions/action_transfer.erl
@@ -1,0 +1,9 @@
+-module(action_transfer).
+-author('Andrey Martemyanov').
+-include_lib("n2o/include/wf.hrl").
+-compile(export_all).
+
+render_action(Record) ->
+	case Record#transfer.state of undefined -> ok; State -> erlang:put(state,State) end,
+	Events = case Record#transfer.events of E when is_list(E) -> E; E -> [E] end,
+	[ self() ! M || M <- Events ], ok.


### PR DESCRIPTION
Forwarding state or messages to WS proc.
Overview:
```erlang
#transfer.state = undefined :: any().
#transfer.events = [] :: [ any() ] | any().
```
Example:
```erlang
main() ->
  MyState = {custom_state, 1,2,3,4,5},
  Cookie = ?CTX#cx.session,
  wf:wire(#transfer{ state=MyState }),
  wf:wire(#transfer{ events = {server, {new_cookie_created, self(), Cookie}} }),
  [].

event(init) ->
  wf:info(?MODULE, "New state reached: ~p", [erlang:get(state)]).
event({server, {new_cookie_created, Pid, C}}) ->
  wf:info(?MODULE, "~p: New cookie event from main ~p reached: ~p", [self(),Pid,C]).
```