### PR TITLE
Log level / Log modules Any implementation

### DIFF
--- a/samples/sys.config
+++ b/samples/sys.config
@@ -1,4 +1,4 @@
 [
- {n2o, [{port,8000},{app,review},{route,routes},{log_modules,config},{event,pickle}]},
+ {n2o, [{port,8000},{app,review},{route,routes},{log_modules,config},{log_level,config},{event,pickle}]},
  {kvs, [{dba,store_mnesia}, {schema, [kvs_user, kvs_acl, kvs_feed, kvs_subscription ]} ]}
 ].

--- a/src/wf.erl
+++ b/src/wf.erl
@@ -166,7 +166,8 @@ reply(Status,Req) -> ?BRIDGE:reply(Status,Req).
 -define(LOGGER, (wf:config(n2o,log_backend,n2o_io))).
 log_modules() -> [wf].
 log_level() -> info.
--define(ALLOWED, (wf:config(n2o,log_modules,wf))).
+-define(LOG_MODULES, (wf:config(n2o,log_modules,wf))).
+-define(LOG_LEVEL, (wf:config(n2o,log_level,wf))).
 
 log_level(none) -> 3;
 log_level(error) -> 2;
@@ -174,11 +175,13 @@ log_level(warning) -> 1;
 log_level(_) -> 0.
 
 log(Module, String, Args, Fun) ->
-    case log_level(Fun) < log_level(?ALLOWED:log_level()) of
+    case log_level(Fun) < log_level(?LOG_LEVEL:log_level()) of
         true -> skip;
-        false -> case lists:member(Module, ?ALLOWED:log_modules()) of
-            true -> ?LOGGER:Fun(Module, String, Args);
-            false -> skip end end.
+        false -> case ?LOG_MODULES:log_modules() of
+            any -> ?LOGGER:Fun(Module, String, Args);
+            Allowed -> case lists:member(Module, Allowed) of
+                true -> ?LOGGER:Fun(Module, String, Args);
+                false -> skip end end end.
 
 info(Module, String, Args) -> log(Module, String, Args, info).
 info(String, Args) -> log(?MODULE, String, Args, info).


### PR DESCRIPTION
Use
```erlang
log_level() -> none.
```
for disabling logging and
```erlang
log_level() -> warning.
```
for logging warning level

Also
```erlang
log_modules() -> any.
```
for logging all modules