### PR TITLE
action_transfer: +state more parameterized

### DIFF
--- a/src/nitrogen/actions/action_transfer.erl
+++ b/src/nitrogen/actions/action_transfer.erl
@@ -4,6 +4,9 @@
 -compile(export_all).
 
 render_action(Record) ->
-	case Record#transfer.state of undefined -> ok; State -> erlang:put(state,State) end,
-	Events = case Record#transfer.events of E when is_list(E) -> E; E -> [E] end,
-	[ self() ! M || M <- Events ], ok.
+    case Record#transfer.state of
+        undefined -> ok;
+        List when is_list(List) -> [ erlang:put(K,V) || {K,V} <- List ];
+        Single -> erlang:put(state,Single) end,
+    Events = case Record#transfer.events of E when is_list(E) -> E; E -> [E] end,
+    [ self() ! M || M <- Events ], ok.


### PR DESCRIPTION
Example
```erlang
body -> ... wf:wire(#transfer{state=[{title,Title},{view,View},{action,Action}]}).
event(init) -> wf:info(?MODULE, "~p", [{get(title),get(view),get(action)}]);
```