### PR TITLE
Use safe option in binary_to_term to prevent atom exhaustion

### DIFF
--- a/src/services/n2o_bert.erl
+++ b/src/services/n2o_bert.erl
@@ -5,5 +5,5 @@
 
 encode(#ftp{}=FTP) -> term_to_binary(setelement(1,FTP,ftpack));
 encode(Term)       -> term_to_binary(Term).
-decode(Bin)        -> binary_to_term(Bin).
+decode(Bin)        -> binary_to_term(Bin,[safe]).
 


### PR DESCRIPTION
If I'm not mistaken, omitting the safe option here leaves a DoS opportunity due to atom exhaustion? (There's always a limit on BEAM)

